### PR TITLE
Sheerid griddle table resize fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Stories in Discussion](https://badge.waffle.io/GriddleGriddle/Griddle.svg?label=ready&title=Discussion)](http://waffle.io/GriddleGriddle/Griddle)
 Griddle
 =======
-#### [Take a brief look at what's coming in Griddle v1.0](https://github.com/GriddleGriddle/Griddle/issues/276) ####
+#### [Take a brief look at what's coming in Griddle v1.0](https://github.com/sheerid/Griddle/issues/276) ####
 ----------
 
 Join us here [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/DynamicTyped/Griddle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -11,13 +11,13 @@ Join us here [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.
 
 ----------
 
-Griddle is a simple grid Component for use with React. It depends on [Lodash Modules](https://lodash.com/) and [React](http://facebook.github.io/react/).
+Griddle is a simple grid Component for use with React. It depends on [Lodash Modules](https://lodash.com/) and [React](http://facebook.github.io/react/).  This repo has been forked by SheerID for private use to include certain enhancements necessary to support internal requirements.
 
 Please check out the [documentation and examples](http://dynamictyped.github.io/Griddle).
 
 To use Griddle:
 
-`npm install griddle-react`
+`npm install @sheerid/griddle-react`
 
 ***Or***
 
@@ -36,6 +36,9 @@ To run from source, type the following commands into a terminal:
 
 Griddle is not yet version 1. There are likely some areas that will change and some issues that you may encounter. Please submit issues / pull requests for anything you run into.
 
+This copy has been forked from GriddleGriddle/Griddle to add support for row double-click and 
+potentially other functionality needed for SheerID use.
+
 ----------
 ###Contributing:###
 
@@ -43,6 +46,10 @@ Please feel free submit any bugs or suggestions as issues. If you are having pro
 
 ----------
 ###Changelog:###
+
+0.1.2 (post-fork)
+**Add**
+* double-click functionality for Griddle rows
 
 0.6.0
 

--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -7816,6 +7816,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            "parentRowCollapsedComponent": "▶",
 	            "parentRowExpandedComponent": "▼",
 	            "onRowClick": null,
+	            "onRowDoubleClick": null,
 	            "multipleSelectionSettings": null
 	        };
 	    },

--- a/build/Griddle.js
+++ b/build/Griddle.js
@@ -82,38 +82,38 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var React = __webpack_require__(2);
 	var GridTable = __webpack_require__(3);
-	var GridFilter = __webpack_require__(175);
-	var GridPagination = __webpack_require__(176);
-	var GridSettings = __webpack_require__(177);
-	var GridNoData = __webpack_require__(183);
-	var GridRow = __webpack_require__(184);
-	var GridRowContainer = __webpack_require__(166);
-	var CustomRowComponentContainer = __webpack_require__(204);
-	var CustomPaginationContainer = __webpack_require__(205);
-	var CustomFilterContainer = __webpack_require__(206);
+	var GridFilter = __webpack_require__(171);
+	var GridPagination = __webpack_require__(172);
+	var GridSettings = __webpack_require__(173);
+	var GridNoData = __webpack_require__(179);
+	var GridRow = __webpack_require__(180);
+	var GridRowContainer = __webpack_require__(162);
+	var CustomRowComponentContainer = __webpack_require__(200);
+	var CustomPaginationContainer = __webpack_require__(201);
+	var CustomFilterContainer = __webpack_require__(202);
 	var ColumnProperties = __webpack_require__(5);
-	var RowProperties = __webpack_require__(173);
-	var deep = __webpack_require__(185);
+	var RowProperties = __webpack_require__(169);
+	var deep = __webpack_require__(181);
 
-	var drop = __webpack_require__(207);
-	var dropRight = __webpack_require__(209);
-	var find = __webpack_require__(130);
-	var first = __webpack_require__(210);
-	var forEach = __webpack_require__(186);
-	var initial = __webpack_require__(211);
-	var intersection = __webpack_require__(212);
-	var isArray = __webpack_require__(71);
-	var isEmpty = __webpack_require__(215);
-	var isNull = __webpack_require__(216);
-	var isUndefined = __webpack_require__(217);
-	var omit = __webpack_require__(218);
+	var drop = __webpack_require__(203);
+	var dropRight = __webpack_require__(205);
+	var find = __webpack_require__(125);
+	var first = __webpack_require__(206);
+	var forEach = __webpack_require__(182);
+	var initial = __webpack_require__(207);
+	var intersection = __webpack_require__(208);
+	var isArray = __webpack_require__(74);
+	var isEmpty = __webpack_require__(211);
+	var isNull = __webpack_require__(212);
+	var isUndefined = __webpack_require__(213);
+	var omit = __webpack_require__(214);
 	var map = __webpack_require__(6);
-	var extend = __webpack_require__(161);
-	var _filter = __webpack_require__(128);
+	var extend = __webpack_require__(157);
+	var _filter = __webpack_require__(122);
 
-	var _orderBy = __webpack_require__(246);
-	var _property = __webpack_require__(119);
-	var _get = __webpack_require__(104);
+	var _orderBy = __webpack_require__(245);
+	var _property = __webpack_require__(113);
+	var _get = __webpack_require__(98);
 
 	var Griddle = React.createClass({
 	    displayName: 'Griddle',
@@ -1014,9 +1014,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var React = __webpack_require__(2);
 	var GridTitle = __webpack_require__(4);
-	var GridRowContainer = __webpack_require__(166);
+	var GridRowContainer = __webpack_require__(162);
 	var ColumnProperties = __webpack_require__(5);
-	var RowProperties = __webpack_require__(173);
+	var RowProperties = __webpack_require__(169);
 
 	var GridTable = React.createClass({
 	  displayName: 'GridTable',
@@ -1309,7 +1309,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var React = __webpack_require__(2);
 	var ColumnProperties = __webpack_require__(5);
-	var assign = __webpack_require__(161);
+	var assign = __webpack_require__(157);
 
 	var DefaultHeaderComponent = React.createClass({
 	    displayName: 'DefaultHeaderComponent',
@@ -1434,10 +1434,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 	var map = __webpack_require__(6);
-	var filter = __webpack_require__(128);
-	var find = __webpack_require__(130);
-	var sortBy = __webpack_require__(137);
-	var difference = __webpack_require__(153);
+	var filter = __webpack_require__(122);
+	var find = __webpack_require__(125);
+	var sortBy = __webpack_require__(132);
+	var difference = __webpack_require__(149);
 
 	var ColumnProperties = (function () {
 	  function ColumnProperties() {
@@ -1537,8 +1537,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var arrayMap = __webpack_require__(7),
 	    baseIteratee = __webpack_require__(8),
-	    baseMap = __webpack_require__(122),
-	    isArray = __webpack_require__(71);
+	    baseMap = __webpack_require__(116),
+	    isArray = __webpack_require__(74);
 
 	/**
 	 * Creates an array of values by running each element in `collection` thru
@@ -1622,10 +1622,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseMatches = __webpack_require__(9),
-	    baseMatchesProperty = __webpack_require__(103),
-	    identity = __webpack_require__(118),
-	    isArray = __webpack_require__(71),
-	    property = __webpack_require__(119);
+	    baseMatchesProperty = __webpack_require__(97),
+	    identity = __webpack_require__(112),
+	    isArray = __webpack_require__(74),
+	    property = __webpack_require__(113);
 
 	/**
 	 * The base implementation of `_.iteratee`.
@@ -1659,8 +1659,8 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseIsMatch = __webpack_require__(10),
-	    getMatchData = __webpack_require__(100),
-	    matchesStrictComparable = __webpack_require__(102);
+	    getMatchData = __webpack_require__(94),
+	    matchesStrictComparable = __webpack_require__(96);
 
 	/**
 	 * The base implementation of `_.matches` which doesn't clone `source`.
@@ -2313,7 +2313,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (value == null) {
 	    return value === undefined ? undefinedTag : nullTag;
 	  }
-	  return (symToStringTag && symToStringTag in Object(value))
+	  value = Object(value);
+	  return (symToStringTag && symToStringTag in value)
 	    ? getRawTag(value)
 	    : objectToString(value);
 	}
@@ -2783,7 +2784,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	function hashHas(key) {
 	  var data = this.__data__;
-	  return nativeCreate ? (data[key] !== undefined) : hasOwnProperty.call(data, key);
+	  return nativeCreate ? data[key] !== undefined : hasOwnProperty.call(data, key);
 	}
 
 	module.exports = hashHas;
@@ -2964,7 +2965,8 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseIsEqualDeep = __webpack_require__(56),
-	    isObjectLike = __webpack_require__(80);
+	    isObject = __webpack_require__(35),
+	    isObjectLike = __webpack_require__(73);
 
 	/**
 	 * The base implementation of `_.isEqual` which supports partial comparisons
@@ -2984,7 +2986,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (value === other) {
 	    return true;
 	  }
-	  if (value == null || other == null || (!isObjectLike(value) && !isObjectLike(other))) {
+	  if (value == null || other == null || (!isObject(value) && !isObjectLike(other))) {
 	    return value !== value && other !== other;
 	  }
 	  return baseIsEqualDeep(value, other, bitmask, customizer, baseIsEqual, stack);
@@ -3001,10 +3003,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    equalArrays = __webpack_require__(57),
 	    equalByTag = __webpack_require__(63),
 	    equalObjects = __webpack_require__(67),
-	    getTag = __webpack_require__(95),
-	    isArray = __webpack_require__(71),
-	    isBuffer = __webpack_require__(81),
-	    isTypedArray = __webpack_require__(85);
+	    getTag = __webpack_require__(89),
+	    isArray = __webpack_require__(74),
+	    isBuffer = __webpack_require__(75),
+	    isTypedArray = __webpack_require__(79);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1;
@@ -3037,12 +3039,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	function baseIsEqualDeep(object, other, bitmask, customizer, equalFunc, stack) {
 	  var objIsArr = isArray(object),
 	      othIsArr = isArray(other),
-	      objTag = objIsArr ? arrayTag : getTag(object),
-	      othTag = othIsArr ? arrayTag : getTag(other);
+	      objTag = arrayTag,
+	      othTag = arrayTag;
 
-	  objTag = objTag == argsTag ? objectTag : objTag;
-	  othTag = othTag == argsTag ? objectTag : othTag;
-
+	  if (!objIsArr) {
+	    objTag = getTag(object);
+	    objTag = objTag == argsTag ? objectTag : objTag;
+	  }
+	  if (!othIsArr) {
+	    othTag = getTag(other);
+	    othTag = othTag == argsTag ? objectTag : othTag;
+	  }
 	  var objIsObj = objTag == objectTag,
 	      othIsObj = othTag == objectTag,
 	      isSameTag = objTag == othTag;
@@ -3479,7 +3486,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 67 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var getAllKeys = __webpack_require__(68);
+	var keys = __webpack_require__(68);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1;
@@ -3505,9 +3512,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
 	  var isPartial = bitmask & COMPARE_PARTIAL_FLAG,
-	      objProps = getAllKeys(object),
+	      objProps = keys(object),
 	      objLength = objProps.length,
-	      othProps = getAllKeys(other),
+	      othProps = keys(other),
 	      othLength = othProps.length;
 
 	  if (objLength != othLength && !isPartial) {
@@ -3574,211 +3581,9 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 68 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetAllKeys = __webpack_require__(69),
-	    getSymbols = __webpack_require__(72),
-	    keys = __webpack_require__(75);
-
-	/**
-	 * Creates an array of own enumerable property names and symbols of `object`.
-	 *
-	 * @private
-	 * @param {Object} object The object to query.
-	 * @returns {Array} Returns the array of property names and symbols.
-	 */
-	function getAllKeys(object) {
-	  return baseGetAllKeys(object, keys, getSymbols);
-	}
-
-	module.exports = getAllKeys;
-
-
-/***/ },
-/* 69 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var arrayPush = __webpack_require__(70),
-	    isArray = __webpack_require__(71);
-
-	/**
-	 * The base implementation of `getAllKeys` and `getAllKeysIn` which uses
-	 * `keysFunc` and `symbolsFunc` to get the enumerable property names and
-	 * symbols of `object`.
-	 *
-	 * @private
-	 * @param {Object} object The object to query.
-	 * @param {Function} keysFunc The function to get the keys of `object`.
-	 * @param {Function} symbolsFunc The function to get the symbols of `object`.
-	 * @returns {Array} Returns the array of property names and symbols.
-	 */
-	function baseGetAllKeys(object, keysFunc, symbolsFunc) {
-	  var result = keysFunc(object);
-	  return isArray(object) ? result : arrayPush(result, symbolsFunc(object));
-	}
-
-	module.exports = baseGetAllKeys;
-
-
-/***/ },
-/* 70 */
-/***/ function(module, exports) {
-
-	/**
-	 * Appends the elements of `values` to `array`.
-	 *
-	 * @private
-	 * @param {Array} array The array to modify.
-	 * @param {Array} values The values to append.
-	 * @returns {Array} Returns `array`.
-	 */
-	function arrayPush(array, values) {
-	  var index = -1,
-	      length = values.length,
-	      offset = array.length;
-
-	  while (++index < length) {
-	    array[offset + index] = values[index];
-	  }
-	  return array;
-	}
-
-	module.exports = arrayPush;
-
-
-/***/ },
-/* 71 */
-/***/ function(module, exports) {
-
-	/**
-	 * Checks if `value` is classified as an `Array` object.
-	 *
-	 * @static
-	 * @memberOf _
-	 * @since 0.1.0
-	 * @category Lang
-	 * @param {*} value The value to check.
-	 * @returns {boolean} Returns `true` if `value` is an array, else `false`.
-	 * @example
-	 *
-	 * _.isArray([1, 2, 3]);
-	 * // => true
-	 *
-	 * _.isArray(document.body.children);
-	 * // => false
-	 *
-	 * _.isArray('abc');
-	 * // => false
-	 *
-	 * _.isArray(_.noop);
-	 * // => false
-	 */
-	var isArray = Array.isArray;
-
-	module.exports = isArray;
-
-
-/***/ },
-/* 72 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var arrayFilter = __webpack_require__(73),
-	    stubArray = __webpack_require__(74);
-
-	/** Used for built-in method references. */
-	var objectProto = Object.prototype;
-
-	/** Built-in value references. */
-	var propertyIsEnumerable = objectProto.propertyIsEnumerable;
-
-	/* Built-in method references for those with the same name as other `lodash` methods. */
-	var nativeGetSymbols = Object.getOwnPropertySymbols;
-
-	/**
-	 * Creates an array of the own enumerable symbols of `object`.
-	 *
-	 * @private
-	 * @param {Object} object The object to query.
-	 * @returns {Array} Returns the array of symbols.
-	 */
-	var getSymbols = !nativeGetSymbols ? stubArray : function(object) {
-	  if (object == null) {
-	    return [];
-	  }
-	  object = Object(object);
-	  return arrayFilter(nativeGetSymbols(object), function(symbol) {
-	    return propertyIsEnumerable.call(object, symbol);
-	  });
-	};
-
-	module.exports = getSymbols;
-
-
-/***/ },
-/* 73 */
-/***/ function(module, exports) {
-
-	/**
-	 * A specialized version of `_.filter` for arrays without support for
-	 * iteratee shorthands.
-	 *
-	 * @private
-	 * @param {Array} [array] The array to iterate over.
-	 * @param {Function} predicate The function invoked per iteration.
-	 * @returns {Array} Returns the new filtered array.
-	 */
-	function arrayFilter(array, predicate) {
-	  var index = -1,
-	      length = array == null ? 0 : array.length,
-	      resIndex = 0,
-	      result = [];
-
-	  while (++index < length) {
-	    var value = array[index];
-	    if (predicate(value, index, array)) {
-	      result[resIndex++] = value;
-	    }
-	  }
-	  return result;
-	}
-
-	module.exports = arrayFilter;
-
-
-/***/ },
-/* 74 */
-/***/ function(module, exports) {
-
-	/**
-	 * This method returns a new empty array.
-	 *
-	 * @static
-	 * @memberOf _
-	 * @since 4.13.0
-	 * @category Util
-	 * @returns {Array} Returns the new empty array.
-	 * @example
-	 *
-	 * var arrays = _.times(2, _.stubArray);
-	 *
-	 * console.log(arrays);
-	 * // => [[], []]
-	 *
-	 * console.log(arrays[0] === arrays[1]);
-	 * // => false
-	 */
-	function stubArray() {
-	  return [];
-	}
-
-	module.exports = stubArray;
-
-
-/***/ },
-/* 75 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var arrayLikeKeys = __webpack_require__(76),
-	    baseKeys = __webpack_require__(90),
-	    isArrayLike = __webpack_require__(94);
+	var arrayLikeKeys = __webpack_require__(69),
+	    baseKeys = __webpack_require__(84),
+	    isArrayLike = __webpack_require__(88);
 
 	/**
 	 * Creates an array of the own enumerable property names of `object`.
@@ -3816,15 +3621,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 76 */
+/* 69 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseTimes = __webpack_require__(77),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71),
-	    isBuffer = __webpack_require__(81),
-	    isIndex = __webpack_require__(84),
-	    isTypedArray = __webpack_require__(85);
+	var baseTimes = __webpack_require__(70),
+	    isArguments = __webpack_require__(71),
+	    isArray = __webpack_require__(74),
+	    isBuffer = __webpack_require__(75),
+	    isIndex = __webpack_require__(78),
+	    isTypedArray = __webpack_require__(79);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -3871,7 +3676,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 77 */
+/* 70 */
 /***/ function(module, exports) {
 
 	/**
@@ -3897,11 +3702,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 78 */
+/* 71 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsArguments = __webpack_require__(79),
-	    isObjectLike = __webpack_require__(80);
+	var baseIsArguments = __webpack_require__(72),
+	    isObjectLike = __webpack_require__(73);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -3939,11 +3744,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 79 */
+/* 72 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseGetTag = __webpack_require__(29),
-	    isObjectLike = __webpack_require__(80);
+	    isObjectLike = __webpack_require__(73);
 
 	/** `Object#toString` result references. */
 	var argsTag = '[object Arguments]';
@@ -3963,7 +3768,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 80 */
+/* 73 */
 /***/ function(module, exports) {
 
 	/**
@@ -3998,11 +3803,43 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 81 */
+/* 74 */
+/***/ function(module, exports) {
+
+	/**
+	 * Checks if `value` is classified as an `Array` object.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @since 0.1.0
+	 * @category Lang
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` is an array, else `false`.
+	 * @example
+	 *
+	 * _.isArray([1, 2, 3]);
+	 * // => true
+	 *
+	 * _.isArray(document.body.children);
+	 * // => false
+	 *
+	 * _.isArray('abc');
+	 * // => false
+	 *
+	 * _.isArray(_.noop);
+	 * // => false
+	 */
+	var isArray = Array.isArray;
+
+	module.exports = isArray;
+
+
+/***/ },
+/* 75 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(31),
-	    stubFalse = __webpack_require__(83);
+	    stubFalse = __webpack_require__(77);
 
 	/** Detect free variable `exports`. */
 	var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -4040,10 +3877,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = isBuffer;
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(82)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(76)(module)))
 
 /***/ },
-/* 82 */
+/* 76 */
 /***/ function(module, exports) {
 
 	module.exports = function(module) {
@@ -4059,7 +3896,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 83 */
+/* 77 */
 /***/ function(module, exports) {
 
 	/**
@@ -4083,7 +3920,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 84 */
+/* 78 */
 /***/ function(module, exports) {
 
 	/** Used as references for various `Number` constants. */
@@ -4111,12 +3948,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 85 */
+/* 79 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIsTypedArray = __webpack_require__(86),
-	    baseUnary = __webpack_require__(88),
-	    nodeUtil = __webpack_require__(89);
+	var baseIsTypedArray = __webpack_require__(80),
+	    baseUnary = __webpack_require__(82),
+	    nodeUtil = __webpack_require__(83);
 
 	/* Node.js helper references. */
 	var nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
@@ -4144,12 +3981,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 86 */
+/* 80 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseGetTag = __webpack_require__(29),
-	    isLength = __webpack_require__(87),
-	    isObjectLike = __webpack_require__(80);
+	    isLength = __webpack_require__(81),
+	    isObjectLike = __webpack_require__(73);
 
 	/** `Object#toString` result references. */
 	var argsTag = '[object Arguments]',
@@ -4210,7 +4047,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 87 */
+/* 81 */
 /***/ function(module, exports) {
 
 	/** Used as references for various `Number` constants. */
@@ -4251,7 +4088,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 88 */
+/* 82 */
 /***/ function(module, exports) {
 
 	/**
@@ -4271,7 +4108,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 89 */
+/* 83 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(module) {var freeGlobal = __webpack_require__(32);
@@ -4297,14 +4134,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = nodeUtil;
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(82)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(76)(module)))
 
 /***/ },
-/* 90 */
+/* 84 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isPrototype = __webpack_require__(91),
-	    nativeKeys = __webpack_require__(92);
+	var isPrototype = __webpack_require__(85),
+	    nativeKeys = __webpack_require__(86);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -4336,7 +4173,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 91 */
+/* 85 */
 /***/ function(module, exports) {
 
 	/** Used for built-in method references. */
@@ -4360,10 +4197,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 92 */
+/* 86 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var overArg = __webpack_require__(93);
+	var overArg = __webpack_require__(87);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeKeys = overArg(Object.keys, Object);
@@ -4372,7 +4209,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 93 */
+/* 87 */
 /***/ function(module, exports) {
 
 	/**
@@ -4393,11 +4230,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 94 */
+/* 88 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var isFunction = __webpack_require__(28),
-	    isLength = __webpack_require__(87);
+	    isLength = __webpack_require__(81);
 
 	/**
 	 * Checks if `value` is array-like. A value is considered array-like if it's
@@ -4432,14 +4269,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 95 */
+/* 89 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var DataView = __webpack_require__(96),
+	var DataView = __webpack_require__(90),
 	    Map = __webpack_require__(25),
-	    Promise = __webpack_require__(97),
-	    Set = __webpack_require__(98),
-	    WeakMap = __webpack_require__(99),
+	    Promise = __webpack_require__(91),
+	    Set = __webpack_require__(92),
+	    WeakMap = __webpack_require__(93),
 	    baseGetTag = __webpack_require__(29),
 	    toSource = __webpack_require__(38);
 
@@ -4496,7 +4333,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 96 */
+/* 90 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var getNative = __webpack_require__(26),
@@ -4509,7 +4346,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 97 */
+/* 91 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var getNative = __webpack_require__(26),
@@ -4522,7 +4359,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 98 */
+/* 92 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var getNative = __webpack_require__(26),
@@ -4535,7 +4372,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 99 */
+/* 93 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var getNative = __webpack_require__(26),
@@ -4548,11 +4385,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 100 */
+/* 94 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isStrictComparable = __webpack_require__(101),
-	    keys = __webpack_require__(75);
+	var isStrictComparable = __webpack_require__(95),
+	    keys = __webpack_require__(68);
 
 	/**
 	 * Gets the property names, values, and compare flags of `object`.
@@ -4578,7 +4415,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 101 */
+/* 95 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var isObject = __webpack_require__(35);
@@ -4599,7 +4436,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 102 */
+/* 96 */
 /***/ function(module, exports) {
 
 	/**
@@ -4625,16 +4462,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 103 */
+/* 97 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseIsEqual = __webpack_require__(55),
-	    get = __webpack_require__(104),
-	    hasIn = __webpack_require__(115),
-	    isKey = __webpack_require__(107),
-	    isStrictComparable = __webpack_require__(101),
-	    matchesStrictComparable = __webpack_require__(102),
-	    toKey = __webpack_require__(114);
+	    get = __webpack_require__(98),
+	    hasIn = __webpack_require__(109),
+	    isKey = __webpack_require__(101),
+	    isStrictComparable = __webpack_require__(95),
+	    matchesStrictComparable = __webpack_require__(96),
+	    toKey = __webpack_require__(108);
 
 	/** Used to compose bitmasks for value comparisons. */
 	var COMPARE_PARTIAL_FLAG = 1,
@@ -4664,10 +4501,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 104 */
+/* 98 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105);
+	var baseGet = __webpack_require__(99);
 
 	/**
 	 * Gets the value at `path` of `object`. If the resolved value is
@@ -4703,11 +4540,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 105 */
+/* 99 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var castPath = __webpack_require__(106),
-	    toKey = __webpack_require__(114);
+	var castPath = __webpack_require__(100),
+	    toKey = __webpack_require__(108);
 
 	/**
 	 * The base implementation of `_.get` without support for default values.
@@ -4733,13 +4570,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 106 */
+/* 100 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArray = __webpack_require__(71),
-	    isKey = __webpack_require__(107),
-	    stringToPath = __webpack_require__(109),
-	    toString = __webpack_require__(112);
+	var isArray = __webpack_require__(74),
+	    isKey = __webpack_require__(101),
+	    stringToPath = __webpack_require__(103),
+	    toString = __webpack_require__(106);
 
 	/**
 	 * Casts `value` to a path array if it's not one.
@@ -4760,11 +4597,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 107 */
+/* 101 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArray = __webpack_require__(71),
-	    isSymbol = __webpack_require__(108);
+	var isArray = __webpack_require__(74),
+	    isSymbol = __webpack_require__(102);
 
 	/** Used to match property names within property paths. */
 	var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
@@ -4795,11 +4632,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 108 */
+/* 102 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseGetTag = __webpack_require__(29),
-	    isObjectLike = __webpack_require__(80);
+	    isObjectLike = __webpack_require__(73);
 
 	/** `Object#toString` result references. */
 	var symbolTag = '[object Symbol]';
@@ -4830,10 +4667,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 109 */
+/* 103 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var memoizeCapped = __webpack_require__(110);
+	var memoizeCapped = __webpack_require__(104);
 
 	/** Used to match property names within property paths. */
 	var reLeadingDot = /^\./,
@@ -4864,10 +4701,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 110 */
+/* 104 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var memoize = __webpack_require__(111);
+	var memoize = __webpack_require__(105);
 
 	/** Used as the maximum memoize cache size. */
 	var MAX_MEMOIZE_SIZE = 500;
@@ -4896,7 +4733,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 111 */
+/* 105 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var MapCache = __webpack_require__(40);
@@ -4975,10 +4812,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 112 */
+/* 106 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseToString = __webpack_require__(113);
+	var baseToString = __webpack_require__(107);
 
 	/**
 	 * Converts `value` to a string. An empty string is returned for `null`
@@ -5009,13 +4846,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 113 */
+/* 107 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var Symbol = __webpack_require__(30),
 	    arrayMap = __webpack_require__(7),
-	    isArray = __webpack_require__(71),
-	    isSymbol = __webpack_require__(108);
+	    isArray = __webpack_require__(74),
+	    isSymbol = __webpack_require__(102);
 
 	/** Used as references for various `Number` constants. */
 	var INFINITY = 1 / 0;
@@ -5052,10 +4889,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 114 */
+/* 108 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isSymbol = __webpack_require__(108);
+	var isSymbol = __webpack_require__(102);
 
 	/** Used as references for various `Number` constants. */
 	var INFINITY = 1 / 0;
@@ -5079,11 +4916,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 115 */
+/* 109 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseHasIn = __webpack_require__(116),
-	    hasPath = __webpack_require__(117);
+	var baseHasIn = __webpack_require__(110),
+	    hasPath = __webpack_require__(111);
 
 	/**
 	 * Checks if `path` is a direct or inherited property of `object`.
@@ -5119,7 +4956,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 116 */
+/* 110 */
 /***/ function(module, exports) {
 
 	/**
@@ -5138,15 +4975,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 117 */
+/* 111 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var castPath = __webpack_require__(106),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71),
-	    isIndex = __webpack_require__(84),
-	    isLength = __webpack_require__(87),
-	    toKey = __webpack_require__(114);
+	var castPath = __webpack_require__(100),
+	    isArguments = __webpack_require__(71),
+	    isArray = __webpack_require__(74),
+	    isIndex = __webpack_require__(78),
+	    isLength = __webpack_require__(81),
+	    toKey = __webpack_require__(108);
 
 	/**
 	 * Checks if `path` exists on `object`.
@@ -5183,7 +5020,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 118 */
+/* 112 */
 /***/ function(module, exports) {
 
 	/**
@@ -5210,13 +5047,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 119 */
+/* 113 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseProperty = __webpack_require__(120),
-	    basePropertyDeep = __webpack_require__(121),
-	    isKey = __webpack_require__(107),
-	    toKey = __webpack_require__(114);
+	var baseProperty = __webpack_require__(114),
+	    basePropertyDeep = __webpack_require__(115),
+	    isKey = __webpack_require__(101),
+	    toKey = __webpack_require__(108);
 
 	/**
 	 * Creates a function that returns the value at `path` of a given object.
@@ -5248,7 +5085,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 120 */
+/* 114 */
 /***/ function(module, exports) {
 
 	/**
@@ -5268,10 +5105,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 121 */
+/* 115 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105);
+	var baseGet = __webpack_require__(99);
 
 	/**
 	 * A specialized version of `baseProperty` which supports deep paths.
@@ -5290,11 +5127,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 122 */
+/* 116 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseEach = __webpack_require__(123),
-	    isArrayLike = __webpack_require__(94);
+	var baseEach = __webpack_require__(117),
+	    isArrayLike = __webpack_require__(88);
 
 	/**
 	 * The base implementation of `_.map` without support for iteratee shorthands.
@@ -5318,11 +5155,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 123 */
+/* 117 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseForOwn = __webpack_require__(124),
-	    createBaseEach = __webpack_require__(127);
+	var baseForOwn = __webpack_require__(118),
+	    createBaseEach = __webpack_require__(121);
 
 	/**
 	 * The base implementation of `_.forEach` without support for iteratee shorthands.
@@ -5338,11 +5175,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 124 */
+/* 118 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFor = __webpack_require__(125),
-	    keys = __webpack_require__(75);
+	var baseFor = __webpack_require__(119),
+	    keys = __webpack_require__(68);
 
 	/**
 	 * The base implementation of `_.forOwn` without support for iteratee shorthands.
@@ -5360,10 +5197,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 125 */
+/* 119 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var createBaseFor = __webpack_require__(126);
+	var createBaseFor = __webpack_require__(120);
 
 	/**
 	 * The base implementation of `baseForOwn` which iterates over `object`
@@ -5382,7 +5219,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 126 */
+/* 120 */
 /***/ function(module, exports) {
 
 	/**
@@ -5413,10 +5250,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 127 */
+/* 121 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArrayLike = __webpack_require__(94);
+	var isArrayLike = __webpack_require__(88);
 
 	/**
 	 * Creates a `baseEach` or `baseEachRight` function.
@@ -5451,13 +5288,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 128 */
+/* 122 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayFilter = __webpack_require__(73),
-	    baseFilter = __webpack_require__(129),
+	var arrayFilter = __webpack_require__(123),
+	    baseFilter = __webpack_require__(124),
 	    baseIteratee = __webpack_require__(8),
-	    isArray = __webpack_require__(71);
+	    isArray = __webpack_require__(74);
 
 	/**
 	 * Iterates over elements of `collection`, returning an array of all elements
@@ -5505,10 +5342,41 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 129 */
+/* 123 */
+/***/ function(module, exports) {
+
+	/**
+	 * A specialized version of `_.filter` for arrays without support for
+	 * iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Array} [array] The array to iterate over.
+	 * @param {Function} predicate The function invoked per iteration.
+	 * @returns {Array} Returns the new filtered array.
+	 */
+	function arrayFilter(array, predicate) {
+	  var index = -1,
+	      length = array == null ? 0 : array.length,
+	      resIndex = 0,
+	      result = [];
+
+	  while (++index < length) {
+	    var value = array[index];
+	    if (predicate(value, index, array)) {
+	      result[resIndex++] = value;
+	    }
+	  }
+	  return result;
+	}
+
+	module.exports = arrayFilter;
+
+
+/***/ },
+/* 124 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseEach = __webpack_require__(123);
+	var baseEach = __webpack_require__(117);
 
 	/**
 	 * The base implementation of `_.filter` without support for iteratee shorthands.
@@ -5532,11 +5400,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 130 */
+/* 125 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var createFind = __webpack_require__(131),
-	    findIndex = __webpack_require__(132);
+	var createFind = __webpack_require__(126),
+	    findIndex = __webpack_require__(127);
 
 	/**
 	 * Iterates over elements of `collection`, returning the first element
@@ -5580,12 +5448,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 131 */
+/* 126 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseIteratee = __webpack_require__(8),
-	    isArrayLike = __webpack_require__(94),
-	    keys = __webpack_require__(75);
+	    isArrayLike = __webpack_require__(88),
+	    keys = __webpack_require__(68);
 
 	/**
 	 * Creates a `_.find` or `_.findLast` function.
@@ -5611,12 +5479,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 132 */
+/* 127 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFindIndex = __webpack_require__(133),
+	var baseFindIndex = __webpack_require__(128),
 	    baseIteratee = __webpack_require__(8),
-	    toInteger = __webpack_require__(134);
+	    toInteger = __webpack_require__(129);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMax = Math.max;
@@ -5672,7 +5540,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 133 */
+/* 128 */
 /***/ function(module, exports) {
 
 	/**
@@ -5702,10 +5570,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 134 */
+/* 129 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var toFinite = __webpack_require__(135);
+	var toFinite = __webpack_require__(130);
 
 	/**
 	 * Converts `value` to an integer.
@@ -5744,10 +5612,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 135 */
+/* 130 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var toNumber = __webpack_require__(136);
+	var toNumber = __webpack_require__(131);
 
 	/** Used as references for various `Number` constants. */
 	var INFINITY = 1 / 0,
@@ -5792,11 +5660,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 136 */
+/* 131 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var isObject = __webpack_require__(35),
-	    isSymbol = __webpack_require__(108);
+	    isSymbol = __webpack_require__(102);
 
 	/** Used as references for various `Number` constants. */
 	var NAN = 0 / 0;
@@ -5864,13 +5732,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 137 */
+/* 132 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFlatten = __webpack_require__(138),
-	    baseOrderBy = __webpack_require__(140),
-	    baseRest = __webpack_require__(144),
-	    isIterateeCall = __webpack_require__(152);
+	var baseFlatten = __webpack_require__(133),
+	    baseOrderBy = __webpack_require__(136),
+	    baseRest = __webpack_require__(140),
+	    isIterateeCall = __webpack_require__(148);
 
 	/**
 	 * Creates an array of elements, sorted in ascending order by the results of
@@ -5918,11 +5786,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 138 */
+/* 133 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayPush = __webpack_require__(70),
-	    isFlattenable = __webpack_require__(139);
+	var arrayPush = __webpack_require__(134),
+	    isFlattenable = __webpack_require__(135);
 
 	/**
 	 * The base implementation of `_.flatten` with support for restricting flattening.
@@ -5962,12 +5830,38 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 139 */
+/* 134 */
+/***/ function(module, exports) {
+
+	/**
+	 * Appends the elements of `values` to `array`.
+	 *
+	 * @private
+	 * @param {Array} array The array to modify.
+	 * @param {Array} values The values to append.
+	 * @returns {Array} Returns `array`.
+	 */
+	function arrayPush(array, values) {
+	  var index = -1,
+	      length = values.length,
+	      offset = array.length;
+
+	  while (++index < length) {
+	    array[offset + index] = values[index];
+	  }
+	  return array;
+	}
+
+	module.exports = arrayPush;
+
+
+/***/ },
+/* 135 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var Symbol = __webpack_require__(30),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71);
+	    isArguments = __webpack_require__(71),
+	    isArray = __webpack_require__(74);
 
 	/** Built-in value references. */
 	var spreadableSymbol = Symbol ? Symbol.isConcatSpreadable : undefined;
@@ -5988,16 +5882,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 140 */
+/* 136 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var arrayMap = __webpack_require__(7),
 	    baseIteratee = __webpack_require__(8),
-	    baseMap = __webpack_require__(122),
-	    baseSortBy = __webpack_require__(141),
-	    baseUnary = __webpack_require__(88),
-	    compareMultiple = __webpack_require__(142),
-	    identity = __webpack_require__(118);
+	    baseMap = __webpack_require__(116),
+	    baseSortBy = __webpack_require__(137),
+	    baseUnary = __webpack_require__(82),
+	    compareMultiple = __webpack_require__(138),
+	    identity = __webpack_require__(112);
 
 	/**
 	 * The base implementation of `_.orderBy` without param guards.
@@ -6028,7 +5922,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 141 */
+/* 137 */
 /***/ function(module, exports) {
 
 	/**
@@ -6055,10 +5949,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 142 */
+/* 138 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var compareAscending = __webpack_require__(143);
+	var compareAscending = __webpack_require__(139);
 
 	/**
 	 * Used by `_.orderBy` to compare multiple properties of a value to another
@@ -6105,10 +5999,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 143 */
+/* 139 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isSymbol = __webpack_require__(108);
+	var isSymbol = __webpack_require__(102);
 
 	/**
 	 * Compares values to sort them in ascending order.
@@ -6152,12 +6046,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 144 */
+/* 140 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var identity = __webpack_require__(118),
-	    overRest = __webpack_require__(145),
-	    setToString = __webpack_require__(147);
+	var identity = __webpack_require__(112),
+	    overRest = __webpack_require__(141),
+	    setToString = __webpack_require__(143);
 
 	/**
 	 * The base implementation of `_.rest` which doesn't validate or coerce arguments.
@@ -6175,10 +6069,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 145 */
+/* 141 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var apply = __webpack_require__(146);
+	var apply = __webpack_require__(142);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMax = Math.max;
@@ -6217,7 +6111,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 146 */
+/* 142 */
 /***/ function(module, exports) {
 
 	/**
@@ -6244,11 +6138,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 147 */
+/* 143 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSetToString = __webpack_require__(148),
-	    shortOut = __webpack_require__(151);
+	var baseSetToString = __webpack_require__(144),
+	    shortOut = __webpack_require__(147);
 
 	/**
 	 * Sets the `toString` method of `func` to return `string`.
@@ -6264,12 +6158,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 148 */
+/* 144 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var constant = __webpack_require__(149),
-	    defineProperty = __webpack_require__(150),
-	    identity = __webpack_require__(118);
+	var constant = __webpack_require__(145),
+	    defineProperty = __webpack_require__(146),
+	    identity = __webpack_require__(112);
 
 	/**
 	 * The base implementation of `setToString` without support for hot loop shorting.
@@ -6292,7 +6186,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 149 */
+/* 145 */
 /***/ function(module, exports) {
 
 	/**
@@ -6324,7 +6218,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 150 */
+/* 146 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var getNative = __webpack_require__(26);
@@ -6341,7 +6235,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 151 */
+/* 147 */
 /***/ function(module, exports) {
 
 	/** Used to detect hot functions by number of calls within a span of milliseconds. */
@@ -6384,12 +6278,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 152 */
+/* 148 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var eq = __webpack_require__(16),
-	    isArrayLike = __webpack_require__(94),
-	    isIndex = __webpack_require__(84),
+	    isArrayLike = __webpack_require__(88),
+	    isIndex = __webpack_require__(78),
 	    isObject = __webpack_require__(35);
 
 	/**
@@ -6420,13 +6314,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 153 */
+/* 149 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseDifference = __webpack_require__(154),
-	    baseFlatten = __webpack_require__(138),
-	    baseRest = __webpack_require__(144),
-	    isArrayLikeObject = __webpack_require__(160);
+	var baseDifference = __webpack_require__(150),
+	    baseFlatten = __webpack_require__(133),
+	    baseRest = __webpack_require__(140),
+	    isArrayLikeObject = __webpack_require__(156);
 
 	/**
 	 * Creates an array of `array` values not included in the other given arrays
@@ -6459,14 +6353,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 154 */
+/* 150 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var SetCache = __webpack_require__(58),
-	    arrayIncludes = __webpack_require__(155),
-	    arrayIncludesWith = __webpack_require__(159),
+	    arrayIncludes = __webpack_require__(151),
+	    arrayIncludesWith = __webpack_require__(155),
 	    arrayMap = __webpack_require__(7),
-	    baseUnary = __webpack_require__(88),
+	    baseUnary = __webpack_require__(82),
 	    cacheHas = __webpack_require__(62);
 
 	/** Used as the size to enable large array optimizations. */
@@ -6532,10 +6426,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 155 */
+/* 151 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIndexOf = __webpack_require__(156);
+	var baseIndexOf = __webpack_require__(152);
 
 	/**
 	 * A specialized version of `_.includes` for arrays without support for
@@ -6555,12 +6449,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 156 */
+/* 152 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFindIndex = __webpack_require__(133),
-	    baseIsNaN = __webpack_require__(157),
-	    strictIndexOf = __webpack_require__(158);
+	var baseFindIndex = __webpack_require__(128),
+	    baseIsNaN = __webpack_require__(153),
+	    strictIndexOf = __webpack_require__(154);
 
 	/**
 	 * The base implementation of `_.indexOf` without `fromIndex` bounds checks.
@@ -6581,7 +6475,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 157 */
+/* 153 */
 /***/ function(module, exports) {
 
 	/**
@@ -6599,7 +6493,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 158 */
+/* 154 */
 /***/ function(module, exports) {
 
 	/**
@@ -6628,7 +6522,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 159 */
+/* 155 */
 /***/ function(module, exports) {
 
 	/**
@@ -6656,11 +6550,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 160 */
+/* 156 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArrayLike = __webpack_require__(94),
-	    isObjectLike = __webpack_require__(80);
+	var isArrayLike = __webpack_require__(88),
+	    isObjectLike = __webpack_require__(73);
 
 	/**
 	 * This method is like `_.isArrayLike` except that it also checks if `value`
@@ -6695,15 +6589,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 161 */
+/* 157 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    copyObject = __webpack_require__(164),
-	    createAssigner = __webpack_require__(165),
-	    isArrayLike = __webpack_require__(94),
-	    isPrototype = __webpack_require__(91),
-	    keys = __webpack_require__(75);
+	var assignValue = __webpack_require__(158),
+	    copyObject = __webpack_require__(160),
+	    createAssigner = __webpack_require__(161),
+	    isArrayLike = __webpack_require__(88),
+	    isPrototype = __webpack_require__(85),
+	    keys = __webpack_require__(68);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -6759,10 +6653,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 162 */
+/* 158 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseAssignValue = __webpack_require__(163),
+	var baseAssignValue = __webpack_require__(159),
 	    eq = __webpack_require__(16);
 
 	/** Used for built-in method references. */
@@ -6793,10 +6687,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 163 */
+/* 159 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var defineProperty = __webpack_require__(150);
+	var defineProperty = __webpack_require__(146);
 
 	/**
 	 * The base implementation of `assignValue` and `assignMergeValue` without
@@ -6824,11 +6718,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 164 */
+/* 160 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    baseAssignValue = __webpack_require__(163);
+	var assignValue = __webpack_require__(158),
+	    baseAssignValue = __webpack_require__(159);
 
 	/**
 	 * Copies properties of `source` to `object`.
@@ -6870,11 +6764,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 165 */
+/* 161 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseRest = __webpack_require__(144),
-	    isIterateeCall = __webpack_require__(152);
+	var baseRest = __webpack_require__(140),
+	    isIterateeCall = __webpack_require__(148);
 
 	/**
 	 * Creates a function like `_.assign`.
@@ -6913,7 +6807,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 166 */
+/* 162 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -6923,7 +6817,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var React = __webpack_require__(2);
 	var ColumnProperties = __webpack_require__(5);
-	var pick = __webpack_require__(167);
+	var pick = __webpack_require__(163);
 
 	var GridRowContainer = React.createClass({
 	  displayName: 'GridRowContainer',
@@ -7043,11 +6937,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridRowContainer;
 
 /***/ },
-/* 167 */
+/* 163 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var basePick = __webpack_require__(168),
-	    flatRest = __webpack_require__(171);
+	var basePick = __webpack_require__(164),
+	    flatRest = __webpack_require__(167);
 
 	/**
 	 * Creates an object composed of the picked `object` properties.
@@ -7074,11 +6968,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 168 */
+/* 164 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var basePickBy = __webpack_require__(169),
-	    hasIn = __webpack_require__(115);
+	var basePickBy = __webpack_require__(165),
+	    hasIn = __webpack_require__(109);
 
 	/**
 	 * The base implementation of `_.pick` without support for individual
@@ -7090,6 +6984,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @returns {Object} Returns the new object.
 	 */
 	function basePick(object, paths) {
+	  object = Object(object);
 	  return basePickBy(object, paths, function(value, path) {
 	    return hasIn(object, path);
 	  });
@@ -7099,12 +6994,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 169 */
+/* 165 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105),
-	    baseSet = __webpack_require__(170),
-	    castPath = __webpack_require__(106);
+	var baseGet = __webpack_require__(99),
+	    baseSet = __webpack_require__(166),
+	    castPath = __webpack_require__(100);
 
 	/**
 	 * The base implementation of  `_.pickBy` without support for iteratee shorthands.
@@ -7135,14 +7030,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 170 */
+/* 166 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    castPath = __webpack_require__(106),
-	    isIndex = __webpack_require__(84),
+	var assignValue = __webpack_require__(158),
+	    castPath = __webpack_require__(100),
+	    isIndex = __webpack_require__(78),
 	    isObject = __webpack_require__(35),
-	    toKey = __webpack_require__(114);
+	    toKey = __webpack_require__(108);
 
 	/**
 	 * The base implementation of `_.set`.
@@ -7188,12 +7083,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 171 */
+/* 167 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var flatten = __webpack_require__(172),
-	    overRest = __webpack_require__(145),
-	    setToString = __webpack_require__(147);
+	var flatten = __webpack_require__(168),
+	    overRest = __webpack_require__(141),
+	    setToString = __webpack_require__(143);
 
 	/**
 	 * A specialized version of `baseRest` which flattens the rest array.
@@ -7210,10 +7105,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 172 */
+/* 168 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseFlatten = __webpack_require__(138);
+	var baseFlatten = __webpack_require__(133);
 
 	/**
 	 * Flattens `array` a single level deep.
@@ -7238,7 +7133,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 173 */
+/* 169 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -7247,7 +7142,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-	var _uniqueId = __webpack_require__(174);
+	var _uniqueId = __webpack_require__(170);
 
 	var RowProperties = (function () {
 	  function RowProperties() {
@@ -7314,10 +7209,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 174 */
+/* 170 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var toString = __webpack_require__(112);
+	var toString = __webpack_require__(106);
 
 	/** Used to generate unique IDs. */
 	var idCounter = 0;
@@ -7348,7 +7243,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 175 */
+/* 171 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7377,7 +7272,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridFilter;
 
 /***/ },
-/* 176 */
+/* 172 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7386,7 +7281,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var assign = __webpack_require__(161);
+	var assign = __webpack_require__(157);
 
 	//needs props maxPage, currentPage, nextFunction, prevFunction
 	var GridPagination = React.createClass({
@@ -7449,7 +7344,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridPagination;
 
 /***/ },
-/* 177 */
+/* 173 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7458,9 +7353,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	var React = __webpack_require__(2);
-	var includes = __webpack_require__(178);
-	var without = __webpack_require__(182);
-	var find = __webpack_require__(130);
+	var includes = __webpack_require__(174);
+	var without = __webpack_require__(178);
+	var find = __webpack_require__(125);
 
 	var GridSettings = React.createClass({
 	    displayName: 'GridSettings',
@@ -7529,14 +7424,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridSettings;
 
 /***/ },
-/* 178 */
+/* 174 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseIndexOf = __webpack_require__(156),
-	    isArrayLike = __webpack_require__(94),
-	    isString = __webpack_require__(179),
-	    toInteger = __webpack_require__(134),
-	    values = __webpack_require__(180);
+	var baseIndexOf = __webpack_require__(152),
+	    isArrayLike = __webpack_require__(88),
+	    isString = __webpack_require__(175),
+	    toInteger = __webpack_require__(129),
+	    values = __webpack_require__(176);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeMax = Math.max;
@@ -7588,12 +7483,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 179 */
+/* 175 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseGetTag = __webpack_require__(29),
-	    isArray = __webpack_require__(71),
-	    isObjectLike = __webpack_require__(80);
+	    isArray = __webpack_require__(74),
+	    isObjectLike = __webpack_require__(73);
 
 	/** `Object#toString` result references. */
 	var stringTag = '[object String]';
@@ -7624,11 +7519,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 180 */
+/* 176 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseValues = __webpack_require__(181),
-	    keys = __webpack_require__(75);
+	var baseValues = __webpack_require__(177),
+	    keys = __webpack_require__(68);
 
 	/**
 	 * Creates an array of the own enumerable string keyed property values of `object`.
@@ -7664,7 +7559,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 181 */
+/* 177 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var arrayMap = __webpack_require__(7);
@@ -7689,12 +7584,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 182 */
+/* 178 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseDifference = __webpack_require__(154),
-	    baseRest = __webpack_require__(144),
-	    isArrayLikeObject = __webpack_require__(160);
+	var baseDifference = __webpack_require__(150),
+	    baseRest = __webpack_require__(140),
+	    isArrayLikeObject = __webpack_require__(156);
 
 	/**
 	 * Creates an array excluding all given values using
@@ -7726,7 +7621,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 183 */
+/* 179 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7754,7 +7649,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridNoData;
 
 /***/ },
-/* 184 */
+/* 180 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -7764,13 +7659,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var React = __webpack_require__(2);
 	var ColumnProperties = __webpack_require__(5);
-	var deep = __webpack_require__(185);
+	var deep = __webpack_require__(181);
 	var isFunction = __webpack_require__(28);
-	var zipObject = __webpack_require__(192);
-	var assign = __webpack_require__(161);
-	var defaults = __webpack_require__(194);
-	var toPairs = __webpack_require__(200);
-	var without = __webpack_require__(182);
+	var zipObject = __webpack_require__(188);
+	var assign = __webpack_require__(157);
+	var defaults = __webpack_require__(190);
+	var toPairs = __webpack_require__(196);
+	var without = __webpack_require__(178);
 
 	var GridRow = React.createClass({
 	    displayName: 'GridRow',
@@ -7927,17 +7822,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = GridRow;
 
 /***/ },
-/* 185 */
+/* 181 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var forEach = __webpack_require__(186);
+	var forEach = __webpack_require__(182);
 	var isObject = __webpack_require__(35);
-	var isArray = __webpack_require__(71);
+	var isArray = __webpack_require__(74);
 	var isFunction = __webpack_require__(28);
-	var isPlainObject = __webpack_require__(189);
-	var forOwn = __webpack_require__(191);
+	var isPlainObject = __webpack_require__(185);
+	var forOwn = __webpack_require__(187);
 
 	// Credits: https://github.com/documentcloud/underscore-contrib
 	// Sub module: underscore.object.selectors
@@ -8082,13 +7977,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 186 */
+/* 182 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayEach = __webpack_require__(187),
-	    baseEach = __webpack_require__(123),
-	    castFunction = __webpack_require__(188),
-	    isArray = __webpack_require__(71);
+	var arrayEach = __webpack_require__(183),
+	    baseEach = __webpack_require__(117),
+	    castFunction = __webpack_require__(184),
+	    isArray = __webpack_require__(74);
 
 	/**
 	 * Iterates over elements of `collection` and invokes `iteratee` for each element.
@@ -8129,7 +8024,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 187 */
+/* 183 */
 /***/ function(module, exports) {
 
 	/**
@@ -8157,10 +8052,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 188 */
+/* 184 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var identity = __webpack_require__(118);
+	var identity = __webpack_require__(112);
 
 	/**
 	 * Casts `value` to `identity` if it's not a function.
@@ -8177,12 +8072,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 189 */
+/* 185 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseGetTag = __webpack_require__(29),
-	    getPrototype = __webpack_require__(190),
-	    isObjectLike = __webpack_require__(80);
+	    getPrototype = __webpack_require__(186),
+	    isObjectLike = __webpack_require__(73);
 
 	/** `Object#toString` result references. */
 	var objectTag = '[object Object]';
@@ -8245,10 +8140,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 190 */
+/* 186 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var overArg = __webpack_require__(93);
+	var overArg = __webpack_require__(87);
 
 	/** Built-in value references. */
 	var getPrototype = overArg(Object.getPrototypeOf, Object);
@@ -8257,11 +8152,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 191 */
+/* 187 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseForOwn = __webpack_require__(124),
-	    castFunction = __webpack_require__(188);
+	var baseForOwn = __webpack_require__(118),
+	    castFunction = __webpack_require__(184);
 
 	/**
 	 * Iterates over own enumerable string keyed properties of an object and
@@ -8299,11 +8194,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 192 */
+/* 188 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var assignValue = __webpack_require__(162),
-	    baseZipObject = __webpack_require__(193);
+	var assignValue = __webpack_require__(158),
+	    baseZipObject = __webpack_require__(189);
 
 	/**
 	 * This method is like `_.fromPairs` except that it accepts two arrays,
@@ -8329,7 +8224,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 193 */
+/* 189 */
 /***/ function(module, exports) {
 
 	/**
@@ -8358,13 +8253,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 194 */
+/* 190 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var apply = __webpack_require__(146),
-	    assignInWith = __webpack_require__(195),
-	    baseRest = __webpack_require__(144),
-	    customDefaultsAssignIn = __webpack_require__(199);
+	var apply = __webpack_require__(142),
+	    assignInDefaults = __webpack_require__(191),
+	    assignInWith = __webpack_require__(192),
+	    baseRest = __webpack_require__(140);
 
 	/**
 	 * Assigns own and inherited enumerable string keyed properties of source
@@ -8388,7 +8283,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * // => { 'a': 1, 'b': 2 }
 	 */
 	var defaults = baseRest(function(args) {
-	  args.push(undefined, customDefaultsAssignIn);
+	  args.push(undefined, assignInDefaults);
 	  return apply(assignInWith, undefined, args);
 	});
 
@@ -8396,12 +8291,45 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 195 */
+/* 191 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    createAssigner = __webpack_require__(165),
-	    keysIn = __webpack_require__(196);
+	var eq = __webpack_require__(16);
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/** Used to check objects for own properties. */
+	var hasOwnProperty = objectProto.hasOwnProperty;
+
+	/**
+	 * Used by `_.defaults` to customize its `_.assignIn` use.
+	 *
+	 * @private
+	 * @param {*} objValue The destination value.
+	 * @param {*} srcValue The source value.
+	 * @param {string} key The key of the property to assign.
+	 * @param {Object} object The parent object of `objValue`.
+	 * @returns {*} Returns the value to assign.
+	 */
+	function assignInDefaults(objValue, srcValue, key, object) {
+	  if (objValue === undefined ||
+	      (eq(objValue, objectProto[key]) && !hasOwnProperty.call(object, key))) {
+	    return srcValue;
+	  }
+	  return objValue;
+	}
+
+	module.exports = assignInDefaults;
+
+
+/***/ },
+/* 192 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var copyObject = __webpack_require__(160),
+	    createAssigner = __webpack_require__(161),
+	    keysIn = __webpack_require__(193);
 
 	/**
 	 * This method is like `_.assignIn` except that it accepts `customizer`
@@ -8440,12 +8368,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 196 */
+/* 193 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayLikeKeys = __webpack_require__(76),
-	    baseKeysIn = __webpack_require__(197),
-	    isArrayLike = __webpack_require__(94);
+	var arrayLikeKeys = __webpack_require__(69),
+	    baseKeysIn = __webpack_require__(194),
+	    isArrayLike = __webpack_require__(88);
 
 	/**
 	 * Creates an array of the own and inherited enumerable property names of `object`.
@@ -8478,12 +8406,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 197 */
+/* 194 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var isObject = __webpack_require__(35),
-	    isPrototype = __webpack_require__(91),
-	    nativeKeysIn = __webpack_require__(198);
+	    isPrototype = __webpack_require__(85),
+	    nativeKeysIn = __webpack_require__(195);
 
 	/** Used for built-in method references. */
 	var objectProto = Object.prototype;
@@ -8517,7 +8445,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 198 */
+/* 195 */
 /***/ function(module, exports) {
 
 	/**
@@ -8543,46 +8471,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 199 */
+/* 196 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var eq = __webpack_require__(16);
-
-	/** Used for built-in method references. */
-	var objectProto = Object.prototype;
-
-	/** Used to check objects for own properties. */
-	var hasOwnProperty = objectProto.hasOwnProperty;
-
-	/**
-	 * Used by `_.defaults` to customize its `_.assignIn` use to assign properties
-	 * of source objects to the destination object for all destination properties
-	 * that resolve to `undefined`.
-	 *
-	 * @private
-	 * @param {*} objValue The destination value.
-	 * @param {*} srcValue The source value.
-	 * @param {string} key The key of the property to assign.
-	 * @param {Object} object The parent object of `objValue`.
-	 * @returns {*} Returns the value to assign.
-	 */
-	function customDefaultsAssignIn(objValue, srcValue, key, object) {
-	  if (objValue === undefined ||
-	      (eq(objValue, objectProto[key]) && !hasOwnProperty.call(object, key))) {
-	    return srcValue;
-	  }
-	  return objValue;
-	}
-
-	module.exports = customDefaultsAssignIn;
-
-
-/***/ },
-/* 200 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var createToPairs = __webpack_require__(201),
-	    keys = __webpack_require__(75);
+	var createToPairs = __webpack_require__(197),
+	    keys = __webpack_require__(68);
 
 	/**
 	 * Creates an array of own enumerable string keyed-value pairs for `object`
@@ -8614,13 +8507,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 201 */
+/* 197 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseToPairs = __webpack_require__(202),
-	    getTag = __webpack_require__(95),
+	var baseToPairs = __webpack_require__(198),
+	    getTag = __webpack_require__(89),
 	    mapToArray = __webpack_require__(65),
-	    setToPairs = __webpack_require__(203);
+	    setToPairs = __webpack_require__(199);
 
 	/** `Object#toString` result references. */
 	var mapTag = '[object Map]',
@@ -8650,7 +8543,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 202 */
+/* 198 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var arrayMap = __webpack_require__(7);
@@ -8674,7 +8567,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 203 */
+/* 199 */
 /***/ function(module, exports) {
 
 	/**
@@ -8698,7 +8591,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 204 */
+/* 200 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -8744,7 +8637,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CustomRowComponentContainer;
 
 /***/ },
-/* 205 */
+/* 201 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -8796,7 +8689,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CustomPaginationContainer;
 
 /***/ },
-/* 206 */
+/* 202 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -8833,11 +8726,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CustomFilterContainer;
 
 /***/ },
-/* 207 */
+/* 203 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208),
-	    toInteger = __webpack_require__(134);
+	var baseSlice = __webpack_require__(204),
+	    toInteger = __webpack_require__(129);
 
 	/**
 	 * Creates a slice of `array` with `n` elements dropped from the beginning.
@@ -8877,7 +8770,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 208 */
+/* 204 */
 /***/ function(module, exports) {
 
 	/**
@@ -8914,11 +8807,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 209 */
+/* 205 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208),
-	    toInteger = __webpack_require__(134);
+	var baseSlice = __webpack_require__(204),
+	    toInteger = __webpack_require__(129);
 
 	/**
 	 * Creates a slice of `array` with `n` elements dropped from the end.
@@ -8959,11 +8852,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 210 */
+/* 206 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208),
-	    toInteger = __webpack_require__(134);
+	var baseSlice = __webpack_require__(204),
+	    toInteger = __webpack_require__(129);
 
 	/**
 	 * Creates a slice of `array` with `n` elements taken from the beginning.
@@ -9002,10 +8895,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 211 */
+/* 207 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseSlice = __webpack_require__(208);
+	var baseSlice = __webpack_require__(204);
 
 	/**
 	 * Gets all but the last element of `array`.
@@ -9030,13 +8923,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 212 */
+/* 208 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var arrayMap = __webpack_require__(7),
-	    baseIntersection = __webpack_require__(213),
-	    baseRest = __webpack_require__(144),
-	    castArrayLikeObject = __webpack_require__(214);
+	    baseIntersection = __webpack_require__(209),
+	    baseRest = __webpack_require__(140),
+	    castArrayLikeObject = __webpack_require__(210);
 
 	/**
 	 * Creates an array of unique values that are included in all given arrays
@@ -9066,14 +8959,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 213 */
+/* 209 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var SetCache = __webpack_require__(58),
-	    arrayIncludes = __webpack_require__(155),
-	    arrayIncludesWith = __webpack_require__(159),
+	    arrayIncludes = __webpack_require__(151),
+	    arrayIncludesWith = __webpack_require__(155),
 	    arrayMap = __webpack_require__(7),
-	    baseUnary = __webpack_require__(88),
+	    baseUnary = __webpack_require__(82),
 	    cacheHas = __webpack_require__(62);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
@@ -9146,10 +9039,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 214 */
+/* 210 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isArrayLikeObject = __webpack_require__(160);
+	var isArrayLikeObject = __webpack_require__(156);
 
 	/**
 	 * Casts `value` to an empty array if it's not an array like object.
@@ -9166,17 +9059,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 215 */
+/* 211 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseKeys = __webpack_require__(90),
-	    getTag = __webpack_require__(95),
-	    isArguments = __webpack_require__(78),
-	    isArray = __webpack_require__(71),
-	    isArrayLike = __webpack_require__(94),
-	    isBuffer = __webpack_require__(81),
-	    isPrototype = __webpack_require__(91),
-	    isTypedArray = __webpack_require__(85);
+	var baseKeys = __webpack_require__(84),
+	    getTag = __webpack_require__(89),
+	    isArguments = __webpack_require__(71),
+	    isArray = __webpack_require__(74),
+	    isArrayLike = __webpack_require__(88),
+	    isBuffer = __webpack_require__(75),
+	    isPrototype = __webpack_require__(85),
+	    isTypedArray = __webpack_require__(79);
 
 	/** `Object#toString` result references. */
 	var mapTag = '[object Map]',
@@ -9249,7 +9142,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 216 */
+/* 212 */
 /***/ function(module, exports) {
 
 	/**
@@ -9277,7 +9170,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 217 */
+/* 213 */
 /***/ function(module, exports) {
 
 	/**
@@ -9305,16 +9198,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 218 */
+/* 214 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var arrayMap = __webpack_require__(7),
-	    baseClone = __webpack_require__(219),
+	    baseClone = __webpack_require__(215),
 	    baseUnset = __webpack_require__(242),
-	    castPath = __webpack_require__(106),
-	    copyObject = __webpack_require__(164),
-	    customOmitClone = __webpack_require__(245),
-	    flatRest = __webpack_require__(171),
+	    castPath = __webpack_require__(100),
+	    copyObject = __webpack_require__(160),
+	    flatRest = __webpack_require__(167),
 	    getAllKeysIn = __webpack_require__(227);
 
 	/** Used to compose bitmasks for cloning. */
@@ -9355,7 +9247,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  });
 	  copyObject(object, getAllKeysIn(object), result);
 	  if (isDeep) {
-	    result = baseClone(result, CLONE_DEEP_FLAG | CLONE_FLAT_FLAG | CLONE_SYMBOLS_FLAG, customOmitClone);
+	    result = baseClone(result, CLONE_DEEP_FLAG | CLONE_FLAT_FLAG | CLONE_SYMBOLS_FLAG);
 	  }
 	  var length = paths.length;
 	  while (length--) {
@@ -9368,28 +9260,28 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 219 */
+/* 215 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var Stack = __webpack_require__(11),
-	    arrayEach = __webpack_require__(187),
-	    assignValue = __webpack_require__(162),
-	    baseAssign = __webpack_require__(220),
-	    baseAssignIn = __webpack_require__(221),
-	    cloneBuffer = __webpack_require__(222),
-	    copyArray = __webpack_require__(223),
-	    copySymbols = __webpack_require__(224),
-	    copySymbolsIn = __webpack_require__(225),
-	    getAllKeys = __webpack_require__(68),
+	    arrayEach = __webpack_require__(183),
+	    assignValue = __webpack_require__(158),
+	    baseAssign = __webpack_require__(216),
+	    baseAssignIn = __webpack_require__(217),
+	    cloneBuffer = __webpack_require__(218),
+	    copyArray = __webpack_require__(219),
+	    copySymbols = __webpack_require__(220),
+	    copySymbolsIn = __webpack_require__(223),
+	    getAllKeys = __webpack_require__(225),
 	    getAllKeysIn = __webpack_require__(227),
-	    getTag = __webpack_require__(95),
+	    getTag = __webpack_require__(89),
 	    initCloneArray = __webpack_require__(228),
 	    initCloneByTag = __webpack_require__(229),
 	    initCloneObject = __webpack_require__(240),
-	    isArray = __webpack_require__(71),
-	    isBuffer = __webpack_require__(81),
+	    isArray = __webpack_require__(74),
+	    isBuffer = __webpack_require__(75),
 	    isObject = __webpack_require__(35),
-	    keys = __webpack_require__(75);
+	    keys = __webpack_require__(68);
 
 	/** Used to compose bitmasks for cloning. */
 	var CLONE_DEEP_FLAG = 1,
@@ -9527,11 +9419,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 220 */
+/* 216 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    keys = __webpack_require__(75);
+	var copyObject = __webpack_require__(160),
+	    keys = __webpack_require__(68);
 
 	/**
 	 * The base implementation of `_.assign` without support for multiple sources
@@ -9550,11 +9442,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 221 */
+/* 217 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    keysIn = __webpack_require__(196);
+	var copyObject = __webpack_require__(160),
+	    keysIn = __webpack_require__(193);
 
 	/**
 	 * The base implementation of `_.assignIn` without support for multiple sources
@@ -9573,7 +9465,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 222 */
+/* 218 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(31);
@@ -9612,10 +9504,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	module.exports = cloneBuffer;
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(82)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(76)(module)))
 
 /***/ },
-/* 223 */
+/* 219 */
 /***/ function(module, exports) {
 
 	/**
@@ -9641,11 +9533,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 224 */
+/* 220 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    getSymbols = __webpack_require__(72);
+	var copyObject = __webpack_require__(160),
+	    getSymbols = __webpack_require__(221);
 
 	/**
 	 * Copies own symbols of `source` to `object`.
@@ -9663,11 +9555,62 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 225 */
+/* 221 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var copyObject = __webpack_require__(164),
-	    getSymbolsIn = __webpack_require__(226);
+	var overArg = __webpack_require__(87),
+	    stubArray = __webpack_require__(222);
+
+	/* Built-in method references for those with the same name as other `lodash` methods. */
+	var nativeGetSymbols = Object.getOwnPropertySymbols;
+
+	/**
+	 * Creates an array of the own enumerable symbols of `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @returns {Array} Returns the array of symbols.
+	 */
+	var getSymbols = nativeGetSymbols ? overArg(nativeGetSymbols, Object) : stubArray;
+
+	module.exports = getSymbols;
+
+
+/***/ },
+/* 222 */
+/***/ function(module, exports) {
+
+	/**
+	 * This method returns a new empty array.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @since 4.13.0
+	 * @category Util
+	 * @returns {Array} Returns the new empty array.
+	 * @example
+	 *
+	 * var arrays = _.times(2, _.stubArray);
+	 *
+	 * console.log(arrays);
+	 * // => [[], []]
+	 *
+	 * console.log(arrays[0] === arrays[1]);
+	 * // => false
+	 */
+	function stubArray() {
+	  return [];
+	}
+
+	module.exports = stubArray;
+
+
+/***/ },
+/* 223 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var copyObject = __webpack_require__(160),
+	    getSymbolsIn = __webpack_require__(224);
 
 	/**
 	 * Copies own and inherited symbols of `source` to `object`.
@@ -9685,13 +9628,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 226 */
+/* 224 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var arrayPush = __webpack_require__(70),
-	    getPrototype = __webpack_require__(190),
-	    getSymbols = __webpack_require__(72),
-	    stubArray = __webpack_require__(74);
+	var arrayPush = __webpack_require__(134),
+	    getPrototype = __webpack_require__(186),
+	    getSymbols = __webpack_require__(221),
+	    stubArray = __webpack_require__(222);
 
 	/* Built-in method references for those with the same name as other `lodash` methods. */
 	var nativeGetSymbols = Object.getOwnPropertySymbols;
@@ -9716,12 +9659,60 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
+/* 225 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseGetAllKeys = __webpack_require__(226),
+	    getSymbols = __webpack_require__(221),
+	    keys = __webpack_require__(68);
+
+	/**
+	 * Creates an array of own enumerable property names and symbols of `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @returns {Array} Returns the array of property names and symbols.
+	 */
+	function getAllKeys(object) {
+	  return baseGetAllKeys(object, keys, getSymbols);
+	}
+
+	module.exports = getAllKeys;
+
+
+/***/ },
+/* 226 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var arrayPush = __webpack_require__(134),
+	    isArray = __webpack_require__(74);
+
+	/**
+	 * The base implementation of `getAllKeys` and `getAllKeysIn` which uses
+	 * `keysFunc` and `symbolsFunc` to get the enumerable property names and
+	 * symbols of `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {Function} keysFunc The function to get the keys of `object`.
+	 * @param {Function} symbolsFunc The function to get the symbols of `object`.
+	 * @returns {Array} Returns the array of property names and symbols.
+	 */
+	function baseGetAllKeys(object, keysFunc, symbolsFunc) {
+	  var result = keysFunc(object);
+	  return isArray(object) ? result : arrayPush(result, symbolsFunc(object));
+	}
+
+	module.exports = baseGetAllKeys;
+
+
+/***/ },
 /* 227 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGetAllKeys = __webpack_require__(69),
-	    getSymbolsIn = __webpack_require__(226),
-	    keysIn = __webpack_require__(196);
+	var baseGetAllKeys = __webpack_require__(226),
+	    getSymbolsIn = __webpack_require__(224),
+	    keysIn = __webpack_require__(193);
 
 	/**
 	 * Creates an array of own and inherited enumerable property names and
@@ -10104,8 +10095,8 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	var baseCreate = __webpack_require__(241),
-	    getPrototype = __webpack_require__(190),
-	    isPrototype = __webpack_require__(91);
+	    getPrototype = __webpack_require__(186),
+	    isPrototype = __webpack_require__(85);
 
 	/**
 	 * Initializes an object clone.
@@ -10163,10 +10154,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 242 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var castPath = __webpack_require__(106),
+	var castPath = __webpack_require__(100),
 	    last = __webpack_require__(243),
 	    parent = __webpack_require__(244),
-	    toKey = __webpack_require__(114);
+	    toKey = __webpack_require__(108);
 
 	/**
 	 * The base implementation of `_.unset`.
@@ -10215,8 +10206,8 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 244 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var baseGet = __webpack_require__(105),
-	    baseSlice = __webpack_require__(208);
+	var baseGet = __webpack_require__(99),
+	    baseSlice = __webpack_require__(204);
 
 	/**
 	 * Gets the parent value at `path` of `object`.
@@ -10237,30 +10228,8 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 245 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var isPlainObject = __webpack_require__(189);
-
-	/**
-	 * Used by `_.omit` to customize its `_.cloneDeep` use to only clone plain
-	 * objects.
-	 *
-	 * @private
-	 * @param {*} value The value to inspect.
-	 * @param {string} key The key of the property to inspect.
-	 * @returns {*} Returns the uncloned value or `undefined` to defer cloning to `_.cloneDeep`.
-	 */
-	function customOmitClone(value) {
-	  return isPlainObject(value) ? undefined : value;
-	}
-
-	module.exports = customOmitClone;
-
-
-/***/ },
-/* 246 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var baseOrderBy = __webpack_require__(140),
-	    isArray = __webpack_require__(71);
+	var baseOrderBy = __webpack_require__(136),
+	    isArray = __webpack_require__(74);
 
 	/**
 	 * This method is like `_.sortBy` except that it allows specifying the sort

--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -1,7 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
    ** modified by coatsbj to support double-click **
-*/
+ */
 'use strict';
 
 var React = require('react');

--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -1,5 +1,6 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
+   ** modified by coatsbj to support double-click **
 */
 'use strict';
 
@@ -42,6 +43,11 @@ var GridRow = React.createClass({
             this.props.onRowClick(this, e);
         } else if (this.props.hasChildren) {
             this.props.toggleChildren();
+        }
+    },
+    handleDoubleClick: function handleDoubleClick(e) {
+        if (this.props.onRowDoubleClick !== null && isFunction(this.props.onRowDoubleClick)) {
+            this.props.onRowDoubleClick(this, e);
         }
     },
     handleSelectionChange: function handleSelectionChange(e) {
@@ -111,13 +117,13 @@ var GridRow = React.createClass({
             if (_this.props.columnSettings.hasColumnMetadata() && typeof meta !== 'undefined' && meta !== null) {
                 if (typeof meta.customComponent !== 'undefined' && meta.customComponent !== null) {
                     var customComponent = React.createElement(meta.customComponent, { data: col[1], rowData: dataView, metadata: meta });
-                    returnValue = React.createElement('td', { onClick: _this.handleClick, className: meta.cssClassName, key: index, style: columnStyles }, customComponent);
+                    returnValue = React.createElement('td', { onClick: _this.handleClick, onDoubleClick: _this.handleDoubleClick, className: meta.cssClassName, key: index, style: columnStyles }, customComponent);
                 } else {
-                    returnValue = React.createElement('td', { onClick: _this.handleClick, className: meta.cssClassName, key: index, style: columnStyles }, firstColAppend, _this.formatData(col[1]));
+                    returnValue = React.createElement('td', { onClick: _this.handleClick, onDoubleClick: _this.handleDoubleClick, className: meta.cssClassName, key: index, style: columnStyles }, firstColAppend, _this.formatData(col[1]));
                 }
             }
 
-            return returnValue || React.createElement('td', { onClick: _this.handleClick, key: index, style: columnStyles }, firstColAppend, col[1]);
+            return returnValue || React.createElement('td', { onClick: _this.handleClick, onDoubleClick: _this.handleDoubleClick, key: index, style: columnStyles }, firstColAppend, col[1]);
         });
 
         // Don't compete with onRowClick, but if no onRowClick function then

--- a/modules/gridRow.jsx.js
+++ b/modules/gridRow.jsx.js
@@ -35,6 +35,7 @@ var GridRow = React.createClass({
             "parentRowCollapsedComponent": "▶",
             "parentRowExpandedComponent": "▼",
             "onRowClick": null,
+            "onRowDoubleClick": null,
             "multipleSelectionSettings": null
         };
     },

--- a/modules/gridRowContainer.jsx.js
+++ b/modules/gridRowContainer.jsx.js
@@ -1,5 +1,6 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
+   ** modified by coatsbj to support double-click **
 */
 'use strict';
 
@@ -78,6 +79,7 @@ var GridRowContainer = React.createClass({
       paddingHeight: that.props.paddingHeight,
       rowHeight: that.props.rowHeight,
       onRowClick: that.props.onRowClick,
+      onRowDoubleClick: that.props.onRowDoubleClick,
       multipleSelectionSettings: this.props.multipleSelectionSettings }));
 
     var children = null;

--- a/modules/gridRowContainer.jsx.js
+++ b/modules/gridRowContainer.jsx.js
@@ -1,7 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
    ** modified by coatsbj to support double-click **
-*/
+ */
 'use strict';
 
 var React = require('react');
@@ -25,6 +25,7 @@ var GridRowContainer = React.createClass({
       "parentRowCollapsedComponent": "▶",
       "parentRowExpandedComponent": "▼",
       "onRowClick": null,
+      "onRowDoubleClick": null,
       "multipleSelectionSettings": null
     };
   },

--- a/modules/gridTable.jsx.js
+++ b/modules/gridTable.jsx.js
@@ -1,5 +1,6 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
+   ** modified by coatsbj to support double-click **
 */
 'use strict';
 
@@ -39,7 +40,8 @@ var GridTable = React.createClass({
       "parentRowExpandedComponent": "▼",
       "externalLoadingComponent": null,
       "externalIsLoading": false,
-      "onRowClick": null
+      "onRowClick": null,
+      "onRowDoubleClick": null
     };
   },
   getInitialState: function getInitialState() {
@@ -159,7 +161,8 @@ var GridTable = React.createClass({
           rowHeight: that.props.rowHeight,
           hasChildren: hasChildren,
           tableClassName: that.props.className,
-          onRowClick: that.props.onRowClick
+          onRowClick: that.props.onRowClick,
+          onRowDoubleClick: that.props.onRowDoubleClick
         });
       });
 

--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -4,8 +4,8 @@
    Copyright (c) 2014 Ryan Lanciaux | DynamicTyped
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
- ** modified by coatsbj to support double-click **
-*/
+   ** modified by coatsbj to support double-click AND to support a fix for grid resizing issues when in virtual scrolling mode **
+ */
 'use strict';
 
 var _extends = Object.assign || function (target) {
@@ -132,6 +132,7 @@ var Griddle = React.createClass({
             "enableSort": true,
             "onRowClick": null,
             "onRowDoubleClick": null,
+            "applyGridResizeFix": false,
             /* css class names */
             "sortAscendingClassName": "sort-ascending",
             "sortDescendingClassName": "sort-descending",
@@ -854,7 +855,8 @@ var Griddle = React.createClass({
             externalIsLoading: this.props.externalIsLoading,
             hasMorePages: hasMorePages,
             onRowClick: this.props.onRowClick,
-            onRowDoubleClick: this.props.onRowDoubleClick}));
+            onRowDoubleClick: this.props.onRowDoubleClick,
+            applyGridResizeFix: this.props.applyGridResizeFix }));
     },
     getContentSection: function getContentSection(data, cols, meta, pagingContent, hasMorePages, globalData) {
         if (this.shouldUseCustomGridComponent() && this.props.customGridComponent !== null) {

--- a/modules/griddle.jsx.js
+++ b/modules/griddle.jsx.js
@@ -4,6 +4,7 @@
    Copyright (c) 2014 Ryan Lanciaux | DynamicTyped
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
+ ** modified by coatsbj to support double-click **
 */
 'use strict';
 
@@ -130,6 +131,7 @@ var Griddle = React.createClass({
             "isSubGriddle": false,
             "enableSort": true,
             "onRowClick": null,
+            "onRowDoubleClick": null,
             /* css class names */
             "sortAscendingClassName": "sort-ascending",
             "sortDescendingClassName": "sort-descending",
@@ -851,7 +853,8 @@ var Griddle = React.createClass({
             externalLoadingComponent: this.props.externalLoadingComponent,
             externalIsLoading: this.props.externalIsLoading,
             hasMorePages: hasMorePages,
-            onRowClick: this.props.onRowClick }));
+            onRowClick: this.props.onRowClick,
+            onRowDoubleClick: this.props.onRowDoubleClick}));
     },
     getContentSection: function getContentSection(data, cols, meta, pagingContent, hasMorePages, globalData) {
         if (this.shouldUseCustomGridComponent() && this.props.customGridComponent !== null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sheerid/griddle-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Griddle - A fast and flexible grid component for React.  Forked and enhanced by SheerID for internal use only.",
   "keywords": [
     "react-component",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sheerid/griddle-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Griddle - A fast and flexible grid component for React.  Forked and enhanced by SheerID for internal use only.",
   "keywords": [
     "react-component",
@@ -52,12 +52,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/GriddleGriddle/Griddle.git"
+    "url": "git://github.com/sheerid/Griddle.git"
   },
-  "author": "GriddleGriddle",
+  "author": "coatsbj",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/GriddleGriddle/Griddle/issues"
+    "url": "https://github.com/sheerid/Griddle/issues"
   },
-  "homepage": "https://github.com/GriddleGriddle/Griddle"
+  "homepage": "https://github.com/sheerid/Griddle"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sheerid/griddle-react",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "Griddle - A fast and flexible grid component for React.  Forked and enhanced by SheerID for internal use only.",
   "keywords": [
     "react-component",

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -1,6 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+   ** modified by coatsbj to support double-click **
+ */
 var React = require('react');
 var ColumnProperties = require('./columnProperties.js');
 var deep = require('./deep.js');
@@ -38,6 +39,11 @@ var GridRow = React.createClass({
             this.props.onRowClick(this, e);
         }else if(this.props.hasChildren){
             this.props.toggleChildren();
+        }
+    },
+    handleDoubleClick: function handleDoubleClick(e) {
+        if (this.props.onRowDoubleClick !== null && isFunction(this.props.onRowDoubleClick)) {
+            this.props.onRowDoubleClick(this, e);
         }
     },
     handleSelectionChange: function(e) {
@@ -108,13 +114,13 @@ var GridRow = React.createClass({
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== 'undefined' && meta !== null) {
               if (typeof meta.customComponent !== 'undefined' && meta.customComponent !== null) {
                 var customComponent = <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
-                returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
+                returnValue = <td onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} className={meta.cssClassName} key={index} style={columnStyles}>{customComponent}</td>;
               } else {
-                returnValue = <td onClick={this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{firstColAppend}{this.formatData(col[1])}</td>;
+                returnValue = <td onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} className={meta.cssClassName} key={index} style={columnStyles}>{firstColAppend}{this.formatData(col[1])}</td>;
               }
             }
 
-            return returnValue || (<td onClick={this.handleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
+            return returnValue || (<td onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} key={index} style={columnStyles}>{firstColAppend}{col[1]}</td>);
         });
 
         // Don't compete with onRowClick, but if no onRowClick function then

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -31,6 +31,7 @@ var GridRow = React.createClass({
         "parentRowCollapsedComponent": "▶",
         "parentRowExpandedComponent": "▼",
         "onRowClick": null,
+        "onRowDoubleClick": null,
 	    "multipleSelectionSettings": null
       }
     },

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -1,6 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+   ** modified by coatsbj to support double-click **
+ */
 var React = require('react');
 var ColumnProperties = require('./columnProperties.js');
 var pick = require('lodash/pick');
@@ -20,7 +21,8 @@ var GridRowContainer = React.createClass({
         "parentRowCollapsedComponent": "▶",
         "parentRowExpandedComponent": "▼",
         "onRowClick": null,
-	    "multipleSelectionSettings": null
+        "onRowDoubleClick": null,
+        "multipleSelectionSettings": null
       };
     },
     getInitialState: function(){
@@ -74,6 +76,7 @@ var GridRowContainer = React.createClass({
           paddingHeight={that.props.paddingHeight}
           rowHeight={that.props.rowHeight}
           onRowClick={that.props.onRowClick}
+          onRowDoubleClick={that.props.onRowDoubleClick}
           multipleSelectionSettings={this.props.multipleSelectionSettings} />
       );
 

--- a/scripts/gridTable.jsx
+++ b/scripts/gridTable.jsx
@@ -1,6 +1,7 @@
 /*
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+ ** modified by coatsbj to support double-click AND to support a fix for grid resizing issues when in virtual scrolling mode **
+ */
 var React = require('react');
 var GridTitle = require('./gridTitle.jsx');
 var GridRowContainer = require('./gridRowContainer.jsx');
@@ -35,7 +36,9 @@ var GridTable = React.createClass({
       "parentRowExpandedComponent": "▼",
       "externalLoadingComponent": null,
       "externalIsLoading": false,
-      "onRowClick": null
+      "onRowClick": null,
+      "onRowDoubleClick": null,
+      "applyGridResizeFix": false
     }
   },
   getInitialState: function(){
@@ -52,6 +55,22 @@ var GridTable = React.createClass({
   componentDidUpdate: function(prevProps, prevState) {
     // After the subsequent renders, see if we need to load additional pages.
     this.gridScroll();
+  },
+  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+      // [BJC, 5/31/2017] NOTE: The following is to ensure grid re-renders upon large-magnitude resize operation when grid was previously quite small in size
+      // [BJC, 5/31/2017] NOTE: Because changing state will force a re-render, we ONLY want to do it if it's ABSOLUTELY necessary
+      if (this.props.applyGridResizeFix
+          && this.props.enableInfiniteScroll
+          && nextProps.enableInfiniteScroll
+          && this.refs.scrollable
+          && nextProps.bodyHeight !== this.props.bodyHeight
+          && this.refs.scrollable.scrollHeight > this.refs.scrollable.clientHeight
+          && (nextProps.bodyHeight - this.state.clientHeight) > nextProps.rowHeight) {
+          this.setState({
+              clientHeight: nextProps.bodyHeight,
+              scrollHeight: (nextProps.bodyHeight > this.state.scrollHeight) ? nextProps.bodyHeight : this.state.scrollHeight
+          });
+      }
   },
   gridScroll: function(){
     if (this.props.enableInfiniteScroll && !this.props.externalIsLoading) {
@@ -75,7 +94,7 @@ var GridTable = React.createClass({
         this.setState(newState);
       }
 
-      // Determine the diff by subtracting the amount scrolled by the total height, taking into consideratoin
+      // Determine the diff by subtracting the amount scrolled by the total height, taking into consideration
       // the spacer's height.
       var scrollHeightDiff = scrollHeight - (scrollTop + clientHeight) - this.props.infiniteScrollLoadTreshold;
 
@@ -152,11 +171,12 @@ var GridTable = React.createClass({
                 columnSettings={that.props.columnSettings}
                 rowSettings={that.props.rowSettings}
                 paddingHeight={that.props.paddingHeight}
-		            multipleSelectionSettings={that.props.multipleSelectionSettings}
+                multipleSelectionSettings={that.props.multipleSelectionSettings}
                 rowHeight={that.props.rowHeight}
                 hasChildren={hasChildren}
                 tableClassName={that.props.className}
                 onRowClick={that.props.onRowClick}
+                onRowDoubleClick={that.props.onRowDoubleClick}
             />
           )
       });

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -4,7 +4,8 @@
    Copyright (c) 2014 Ryan Lanciaux | DynamicTyped
 
    See License / Disclaimer https://raw.githubusercontent.com/DynamicTyped/Griddle/master/LICENSE
-*/
+   ** modified by coatsbj to support double-click AND to support a fix for grid resizing issues when in virtual scrolling mode **
+ */
 var React = require('react');
 var GridTable = require('./gridTable.jsx');
 var GridFilter = require('./gridFilter.jsx');
@@ -116,6 +117,8 @@ var Griddle = React.createClass({
             "isSubGriddle": false,
             "enableSort": true,
             "onRowClick": null,
+            "onRowDoubleClick": null,
+            "applyGridResizeFix": false,
             /* css class names */
             "sortAscendingClassName": "sort-ascending",
             "sortDescendingClassName": "sort-descending",
@@ -732,7 +735,7 @@ var Griddle = React.createClass({
 			getIsSelectAllChecked: this._getIsSelectAllChecked,
 			toggleSelectRow: this._toggleSelectRow,
 			getSelectedRowIds: this.getSelectedRowIds,
-      getIsRowChecked: this._getIsRowChecked
+            getIsRowChecked: this._getIsRowChecked
 		}
 	},
     isInfiniteScrollEnabled: function(){
@@ -877,7 +880,9 @@ var Griddle = React.createClass({
                 externalLoadingComponent={this.props.externalLoadingComponent}
                 externalIsLoading={this.props.externalIsLoading}
                 hasMorePages={hasMorePages}
-                onRowClick={this.props.onRowClick}/></div>)
+                onRowClick={this.props.onRowClick}
+                onRowDoubleClick={this.props.onRowDoubleClick}
+                applyGridResizeFix={this.props.applyGridResizeFix}/></div>)
     },
     getContentSection: function(data, cols, meta, pagingContent, hasMorePages, globalData){
         if(this.shouldUseCustomGridComponent() && this.props.customGridComponent !== null){


### PR DESCRIPTION
*** NOTE: THE COMMIT INCLUDES THE ACTUAL COMPILED OUTPUT, AS IT WAS ALREADY BEING INCLUDED.  THIS MAY CHANGE IN THE FUTURE.  YOU ONLY NEED TO FOCUS ON THE *.jsx FILES, NOT ANY *.js OR *.jsx.js FILES! **

** 0.1.4 update contains: **
- A fix for resizing (massive expansion) grid in virtualized mode, to ensure displayed rows update in this case
- Previously, double-click functionality was addressed through /modules files. Couldn't figure out why this stuff kept getting overwritten. Finally took a look and saw that these *.jsx.js files were created via a babel process in the grunt file, and the *source* for those quasi-compiled files were the /scripts/*.jsx files. Applied previous changes to the .jsx files to ensure work wouldn't be overwritten in future builds
- Incremented the version number

A subsequent fix is pending for performance on scroll of certain records...need to throttle re-rendering for virtualized rows with wrapped content. However, this fix has some quirks, so keeping it out of 0.1.4 unless a defect is logged for it, will put in a separate 0.1.5 branch.